### PR TITLE
feat: Add write permissions for contents and packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.67.0
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   create_release:
     name: 📦 Create Release


### PR DESCRIPTION
This commit adds write permissions for the `contents` and `packages` scopes in the GitHub Actions workflow for the release process. This ensures that the workflow can write to the repository and publish packages as part of the release process.