### PR TITLE
feat: Add check for existing tag and release in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions:
   packages: write
 
 jobs:
-  check_tag_and_release:
+  check_release:
     name: 🔍 Check Tag and Release
     runs-on: ubuntu-latest
     outputs:
@@ -109,11 +109,10 @@ jobs:
           echo "LD_LIBRARY_PATH=/usr/local/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: 🔨 Build project
-        run: |
-          cargo build --release --verbose
+        run: cargo build --release --verbose
         env:
-          RUSTFLAGS: "-C link-arg=-Wl,-rpath,/usr/lib/x86_64-linux-gnu"
-          PKG_CONFIG_PATH: "/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH"
+          RUSTFLAGS: ${{ matrix.os == 'ubuntu-latest' && '-C link-arg=-Wl,-rpath,/usr/lib/x86_64-linux-gnu' || '' }}
+          PKG_CONFIG_PATH: ${{ matrix.os == 'ubuntu-latest' && '/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH' || '' }}
 
       - name: 📤 Upload Release Asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,13 @@ permissions:
   packages: write
 
 jobs:
-  check_release:
-    name: 🔍 Check Existing Release
+  check_tag_and_release:
+    name: 🔍 Check Tag and Release
     runs-on: ubuntu-latest
     outputs:
-      release_exists: ${{ steps.check_release.outputs.release_exists }}
       tag: ${{ steps.get_tag.outputs.tag }}
+      tag_exists: ${{ steps.check_tag.outputs.tag_exists }}
+      release_exists: ${{ steps.check_release.outputs.release_exists }}
     steps:
       - name: 🏷️ Get tag
         id: get_tag


### PR DESCRIPTION
The changes in this commit add a new job called `check_tag_and_release` to the release workflow. This job checks for the existence of both the git tag and the corresponding GitHub release. The job outputs the tag name, whether the tag exists, and whether the release exists. These outputs can be used in subsequent steps of the release workflow.