### PR TITLE
fix: Update Rust version to 1.70.0 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.67.0
+  RUST_VERSION: 1.70.0  # Updated to 1.70.0 to meet tokio's requirements
 
 permissions:
   contents: write


### PR DESCRIPTION
The Rust version was updated from 1.67.0 to 1.70.0 in the release workflow to meet the requirements of the tokio dependency.