### PR TITLE
feat: Add installation script for Inspector Gadget CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.get_tag.outputs.tag }}
-      tag_exists: ${{ steps.check_tag.outputs.tag_exists }}
       release_exists: ${{ steps.check_release.outputs.release_exists }}
     steps:
       - name: 🏷️ Get tag
@@ -93,7 +92,7 @@ jobs:
             artifact_name: inspector-gadget-cli
             asset_name: inspector-gadget-cli-macos-amd64
     steps:
-      - name: 📥 Checkout repository
+      - name: ���� Checkout repository
         uses: actions/checkout@v4
 
       - name: 🦀 Setup Rust toolchain

--- a/README.md
+++ b/README.md
@@ -6,25 +6,19 @@ A powerful CLI tool for inspecting and analyzing web links. Handy when it comes 
 
 ## Installation
 
-You can install Inspector Gadget CLI by downloading the pre-built binary for your operating system from the [latest release](https://github.com/Excoriate/inspector-gadget-cli/releases/latest) page.
+You can install the Inspector Gadget CLI using our installation script:
 
-### Linux and macOS
+```bash
+curl -L https://raw.githubusercontent.com/Excoriate/inspector-gadget-cli/main/install/install.sh | sh
+```
 
-1. Download the appropriate binary for your system (e.g., `inspector-gadget-cli-linux-amd64` for Linux or `inspector-gadget-cli-macos-amd64` for macOS).
-2. Make the binary executable:
-   ```
-   chmod +x inspector-gadget-cli-*
-   ```
-3. Move the binary to a directory in your PATH, for example:
-   ```
-   sudo mv inspector-gadget-cli-* /usr/local/bin/inspector
-   ```
+By default, this will install the latest version. If you want to install a specific version, you can use:
 
-### Windows
+```bash
+curl -L https://raw.githubusercontent.com/Excoriate/inspector-gadget-cli/main/install/install.sh | INSPECTOR_GADGET_VERSION=v0.0.1 sh
+```
 
-1. Download the Windows binary (`inspector-gadget-cli-windows-amd64.exe`).
-2. Rename it to `inspector.exe` for convenience.
-3. Move the executable to a directory in your PATH or create a new directory and add it to your PATH.
+The CLI will be installed in `/usr/local/bin`.
 
 ## Usage
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+VERSION=${INSPECTOR_GADGET_VERSION:-latest}
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+if [ "$ARCH" = "x86_64" ]; then
+    ARCH="amd64"
+elif [ "$ARCH" = "aarch64" ]; then
+    ARCH="arm64"
+fi
+
+BINARY_URL="https://github.com/Excoriate/inspector-gadget-cli/releases/download/${VERSION}/inspector-gadget-cli_${VERSION}_${OS}_${ARCH}"
+
+echo "Downloading Inspector Gadget CLI version ${VERSION} for ${OS}_${ARCH}..."
+echo "URL: ${BINARY_URL}"
+
+if ! curl -L -o inspector-gadget-cli "${BINARY_URL}"; then
+    echo "Error: Failed to download the binary"
+    exit 1
+fi
+
+echo "Verifying download..."
+if ! [ -s inspector-gadget-cli ]; then
+    echo "Error: Downloaded file is empty or does not exist"
+    echo "Content of the file:"
+    cat inspector-gadget-cli
+    exit 1
+fi
+
+echo "File size: $(wc -c < inspector-gadget-cli) bytes"
+echo "File type: $(file inspector-gadget-cli)"
+
+echo "Installing Inspector Gadget CLI..."
+chmod +x inspector-gadget-cli
+if ! sudo mv inspector-gadget-cli /usr/local/bin/; then
+    echo "Error: Failed to move the binary to /usr/local/bin/"
+    exit 1
+fi
+
+echo "Inspector Gadget CLI installed successfully in /usr/local/bin"
+echo "Verifying installation..."
+if inspector-gadget-cli --version; then
+    echo "Inspector Gadget CLI installed successfully!"
+else
+    echo "Error: Installation verification failed. Please check your PATH and try running 'inspector-gadget-cli --version' manually."
+fi

--- a/justfile
+++ b/justfile
@@ -73,3 +73,31 @@ docker-ci:
 fix:
     cargo fix --allow-dirty
     cargo fmt
+
+# Install the CLI using the install.sh script
+install-cli:
+    @echo "Installing CLI using install.sh script..."
+    @curl -fsSL https://raw.githubusercontent.com/your-repo/install.sh | sh
+
+# Install the CLI using the install.sh script locally
+install-cli-local *version:
+    @echo "Installing CLI using install.sh script..."
+    @echo "Version: {{version}}"
+    @if [ -f ./install/install.sh ]; then \
+        chmod +x ./install/install.sh && \
+        INSPECTOR_GADGET_VERSION={{version}} ./install/install.sh; \
+    else \
+        echo "Error: install.sh script not found in ./install directory"; \
+        exit 1; \
+    fi
+    @echo "Verifying installation..."
+    @if command -v inspector-gadget-cli >/dev/null 2>&1; then \
+        echo "inspector-gadget-cli is installed at: $(which inspector-gadget-cli)"; \
+        echo "File type: $(file $(which inspector-gadget-cli))"; \
+        echo "File content:"; \
+        cat $(which inspector-gadget-cli); \
+        inspector-gadget-cli --version || echo "Failed to run --version"; \
+    else \
+        echo "Error: inspector-gadget-cli not found in PATH"; \
+        exit 1; \
+    fi


### PR DESCRIPTION
This commit adds a new installation script for the Inspector Gadget CLI. The script allows users to install the latest version or a specific version of the CLI by running a single command.

The key changes include:

- Add a new `install.sh` script in the `install/` directory
- The script automatically determines the operating system and architecture, and downloads the appropriate binary
- The script allows the user to specify the version of the CLI to install using an environment variable
- Update the README.md file to include the new installation instructions