### PR TITLE
Here is a clear and concise commit message summarizing the changes:

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,16 +83,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            artifact_name: inspector-gadget-cli
+            artifact_name: inspector-gadget
             asset_name: inspector-gadget-cli-linux-amd64
           - os: windows-latest
-            artifact_name: inspector-gadget-cli.exe
+            artifact_name: inspector-gadget.exe
             asset_name: inspector-gadget-cli-windows-amd64.exe
           - os: macOS-latest
-            artifact_name: inspector-gadget-cli
+            artifact_name: inspector-gadget
             asset_name: inspector-gadget-cli-macos-amd64
     steps:
-      - name: ���� Checkout repository
+      - name: 📥 Checkout repository
         uses: actions/checkout@v4
 
       - name: 🦀 Setup Rust toolchain
@@ -112,6 +112,9 @@ jobs:
         env:
           RUSTFLAGS: ${{ matrix.os == 'ubuntu-latest' && '-C link-arg=-Wl,-rpath,/usr/lib/x86_64-linux-gnu' || '' }}
           PKG_CONFIG_PATH: ${{ matrix.os == 'ubuntu-latest' && '/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH' || '' }}
+
+      - name: 📋 List target directory
+        run: ls -R ./target/release
 
       - name: 📤 Upload Release Asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
ci: Update release workflow to list target directory and rename artifact

This commit updates the release workflow in the .github/workflows/release.yml file. The changes include:

1. Adding a step to list the contents of the target/release directory for debugging purposes.
2. Renaming the artifact names to remove the "-cli" suffix for the various OS builds. The new artifact names are:
   - ubuntu-latest: "inspector-gadget"
   - windows-latest: "inspector-gadget.exe"
   - macOS-latest: "inspector-gadget"

These changes ensure the release workflow is correctly producing and uploading the expected artifact names.