### PR TITLE
feat: Enhance CLI installation experience

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,31 +126,6 @@ jobs:
           asset_name: ${{ matrix.asset_name }}
           asset_content_type: application/octet-stream
 
-  update_readme:
-    name: 📝 Update README
-    needs: [check_release, create_release, build_and_upload]
-    if: needs.check_release.outputs.release_exists == 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
-
-      - name: 🔄 Update README with new version
-        run: |
-          sed -i 's/v[0-9]\+\.[0-9]\+\.[0-9]\+/${{ needs.check_release.outputs.tag }}/g' README.md
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git commit -am "Update README for ${{ needs.check_release.outputs.tag }}"
-          git push
-
-      - name: 🎉 Release Success Notification
-        if: success()
-        run: echo "::notice::🎊 Successfully released new version and updated README!"
-
-      - name: ❌ Release Failure Notification
-        if: failure()
-        run: echo "::error::💥 Failed to release new version or update README. Please check the logs for details."
-
   notify_existing_release:
     name: 📢 Notify Existing Release
     needs: check_release

--- a/install/install.sh
+++ b/install/install.sh
@@ -12,7 +12,13 @@ elif [ "$ARCH" = "aarch64" ]; then
     ARCH="arm64"
 fi
 
-BINARY_URL="https://github.com/Excoriate/inspector-gadget-cli/releases/download/${VERSION}/inspector-gadget-cli_${VERSION}_${OS}_${ARCH}"
+# Updated binary name format based on the confirmed release
+BINARY_NAME="inspector-gadget-cli-${OS}-${ARCH}"
+if [ "$OS" = "windows" ]; then
+    BINARY_NAME="${BINARY_NAME}.exe"
+fi
+
+BINARY_URL="https://github.com/Excoriate/inspector-gadget-cli/releases/download/${VERSION}/${BINARY_NAME}"
 
 echo "Downloading Inspector Gadget CLI version ${VERSION} for ${OS}_${ARCH}..."
 echo "URL: ${BINARY_URL}"

--- a/justfile
+++ b/justfile
@@ -79,9 +79,9 @@ install-cli:
     @echo "Installing CLI using install.sh script..."
     @curl -fsSL https://raw.githubusercontent.com/your-repo/install.sh | sh
 
-# Install the CLI using the install.sh script locally
+# Install the CLI using the local install.sh script
 install-cli-local *version:
-    @echo "Installing CLI using install.sh script..."
+    @echo "Installing CLI using local install.sh script..."
     @echo "Version: {{version}}"
     @if [ -f ./install/install.sh ]; then \
         chmod +x ./install/install.sh && \


### PR DESCRIPTION
- Update install-cli-local target in justfile to clarify it uses the local install.sh script
- Refactor install.sh script to use a more descriptive binary name format based on the OS and architecture
- Remove unnecessary 'update_readme' job from the release workflow as it is not needed