### PR TITLE
feat: Improve binary naming and installation script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,13 +84,13 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact_name: inspector-gadget
-            asset_name: inspector-gadget-cli-linux-amd64
+            asset_name: inspector-gadget-linux-amd64
           - os: windows-latest
             artifact_name: inspector-gadget.exe
-            asset_name: inspector-gadget-cli-windows-amd64.exe
+            asset_name: inspector-gadget-windows-amd64.exe
           - os: macOS-latest
             artifact_name: inspector-gadget
-            asset_name: inspector-gadget-cli-macos-amd64
+            asset_name: inspector-gadget-macos-amd64
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4

--- a/install/install.sh
+++ b/install/install.sh
@@ -12,44 +12,44 @@ elif [ "$ARCH" = "aarch64" ]; then
     ARCH="arm64"
 fi
 
-# Updated binary name format based on the confirmed release
-BINARY_NAME="inspector-gadget-cli-${OS}-${ARCH}"
+# Updated binary name format based on the correct release asset name
+BINARY_NAME="inspector-gadget-${OS}-${ARCH}"
 if [ "$OS" = "windows" ]; then
     BINARY_NAME="${BINARY_NAME}.exe"
 fi
 
-BINARY_URL="https://github.com/Excoriate/inspector-gadget-cli/releases/download/${VERSION}/${BINARY_NAME}"
+BINARY_URL="https://github.com/Excoriate/inspector-gadget/releases/download/${VERSION}/${BINARY_NAME}"
 
-echo "Downloading Inspector Gadget CLI version ${VERSION} for ${OS}_${ARCH}..."
+echo "Downloading Inspector Gadget version ${VERSION} for ${OS}_${ARCH}..."
 echo "URL: ${BINARY_URL}"
 
-if ! curl -L -o inspector-gadget-cli "${BINARY_URL}"; then
+if ! curl -L -o inspector-gadget "${BINARY_URL}"; then
     echo "Error: Failed to download the binary"
     exit 1
 fi
 
 echo "Verifying download..."
-if ! [ -s inspector-gadget-cli ]; then
+if ! [ -s inspector-gadget ]; then
     echo "Error: Downloaded file is empty or does not exist"
     echo "Content of the file:"
-    cat inspector-gadget-cli
+    cat inspector-gadget
     exit 1
 fi
 
-echo "File size: $(wc -c < inspector-gadget-cli) bytes"
-echo "File type: $(file inspector-gadget-cli)"
+echo "File size: $(wc -c < inspector-gadget) bytes"
+echo "File type: $(file inspector-gadget)"
 
-echo "Installing Inspector Gadget CLI..."
-chmod +x inspector-gadget-cli
-if ! sudo mv inspector-gadget-cli /usr/local/bin/; then
+echo "Installing Inspector Gadget..."
+chmod +x inspector-gadget
+if ! sudo mv inspector-gadget /usr/local/bin/; then
     echo "Error: Failed to move the binary to /usr/local/bin/"
     exit 1
 fi
 
-echo "Inspector Gadget CLI installed successfully in /usr/local/bin"
+echo "Inspector Gadget installed successfully in /usr/local/bin"
 echo "Verifying installation..."
-if inspector-gadget-cli --version; then
-    echo "Inspector Gadget CLI installed successfully!"
+if inspector-gadget --version; then
+    echo "Inspector Gadget installed successfully!"
 else
-    echo "Error: Installation verification failed. Please check your PATH and try running 'inspector-gadget-cli --version' manually."
+    echo "Error: Installation verification failed. Please check your PATH and try running 'inspector-gadget --version' manually."
 fi

--- a/justfile
+++ b/justfile
@@ -2,6 +2,30 @@
 default:
     @just --list
 
+# Show help information about the CLI
+help:
+    @echo "Inspector CLI Help"
+    @echo "==================="
+    @echo "This CLI tool inspects and analyzes web links on documentation sites."
+    @echo ""
+    @echo "Usage:"
+    @echo "  inspector-cli [OPTIONS] <URL>"
+    @echo ""
+    @echo "Options:"
+    @echo "  -o, --output-format <FORMAT>  Output format: json, yaml, txt, or clipboard"
+    @echo "  -f, --output-file <FILE>      Output file name"
+    @echo "  -l, --log-level <LEVEL>       Log level: info, debug, or error"
+    @echo "  -s, --show-links              Show links in the terminal"
+    @echo "  -d, --detailed                Show detailed information including ignored links"
+    @echo "  --config <FILE>               Sets a custom config file"
+    @echo "  --ignore-domains <DOMAINS>    Comma-separated list of domains to ignore"
+    @echo "  --ignore-regex <REGEX>        Comma-separated list of regex patterns to ignore URLs"
+    @echo "  --forbidden-domains <DOMAINS> Comma-separated list of forbidden domains"
+    @echo "  --ignored-childs <PATHS>      Comma-separated list of child paths to ignore"
+    @echo "  --timeout <SECONDS>           Timeout in seconds for each HTTP request"
+    @echo ""
+    @echo "For more information, run: cargo run -- --help"
+
 # Run all tests
 test:
     cargo test
@@ -96,8 +120,15 @@ install-cli-local *version:
         echo "File type: $(file $(which inspector-gadget-cli))"; \
         echo "File content:"; \
         cat $(which inspector-gadget-cli); \
-        inspector-gadget-cli --version || echo "Failed to run --version"; \
+        inspector-gadget-cli --help || echo "Failed to run --version"; \
     else \
         echo "Error: inspector-gadget-cli not found in PATH"; \
         exit 1; \
     fi
+
+# Compile the binary locally and run it
+compile-and-run *args:
+    @echo "Compiling inspector-gadget-cli..."
+    cargo build --release
+    @echo "Running inspector-gadget-cli..."
+    ./target/release/inspector-gadget {{args}}


### PR DESCRIPTION
- Update the binary name format to match the correct release asset name
- Update the binary download URL to point to the correct repository and version
- Rename the binary from `inspector-gadget-cli` to `inspector-gadget`
- Update the installation script to reflect the new binary name
- Add a new `compile-and-run` command to the justfile for local development