### PR TITLE
feat: Add support for multiple targets in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,10 @@ jobs:
           - os: macOS-latest
             artifact_name: inspector-gadget
             asset_name: inspector-gadget-macos-amd64
+          - os: macOS-latest
+            artifact_name: inspector-gadget
+            asset_name: inspector-gadget-macos-arm64
+            target: aarch64-apple-darwin
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
@@ -99,6 +103,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
+          targets: ${{ matrix.target }}
 
       - name: 📦 Install dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -108,13 +113,23 @@ jobs:
           echo "LD_LIBRARY_PATH=/usr/local/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: 🔨 Build project
-        run: cargo build --release --verbose
+        run: |
+          if [ "${{ matrix.target }}" != "" ]; then
+            cargo build --release --verbose --target ${{ matrix.target }}
+          else
+            cargo build --release --verbose
+          fi
         env:
           RUSTFLAGS: ${{ matrix.os == 'ubuntu-latest' && '-C link-arg=-Wl,-rpath,/usr/lib/x86_64-linux-gnu' || '' }}
           PKG_CONFIG_PATH: ${{ matrix.os == 'ubuntu-latest' && '/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH' || '' }}
 
       - name: 📋 List target directory
-        run: ls -R ./target/release
+        run: |
+          if [ "${{ matrix.target }}" != "" ]; then
+            ls -R ./target/${{ matrix.target }}/release
+          else
+            ls -R ./target/release
+          fi
 
       - name: 📤 Upload Release Asset
         uses: actions/upload-release-asset@v1
@@ -122,7 +137,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ./target/release/${{ matrix.artifact_name }}
+          asset_path: ${{ matrix.target != '' && format('./target/{0}/release/{1}', matrix.target, matrix.artifact_name) || format('./target/release/{0}', matrix.artifact_name) }}
           asset_name: ${{ matrix.asset_name }}
           asset_content_type: application/octet-stream
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -8,7 +8,7 @@ ARCH=$(uname -m)
 
 if [ "$ARCH" = "x86_64" ]; then
     ARCH="amd64"
-elif [ "$ARCH" = "aarch64" ]; then
+elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
     ARCH="arm64"
 fi
 
@@ -18,9 +18,9 @@ if [ "$OS" = "windows" ]; then
     BINARY_NAME="${BINARY_NAME}.exe"
 fi
 
-BINARY_URL="https://github.com/Excoriate/inspector-gadget/releases/download/${VERSION}/${BINARY_NAME}"
+BINARY_URL="https://github.com/Excoriate/inspector-gadget-cli/releases/download/${VERSION}/${BINARY_NAME}"
 
-echo "Downloading Inspector Gadget version ${VERSION} for ${OS}_${ARCH}..."
+echo "Downloading Inspector Gadget CLI version ${VERSION} for ${OS}_${ARCH}..."
 echo "URL: ${BINARY_URL}"
 
 if ! curl -L -o inspector-gadget "${BINARY_URL}"; then
@@ -39,17 +39,17 @@ fi
 echo "File size: $(wc -c < inspector-gadget) bytes"
 echo "File type: $(file inspector-gadget)"
 
-echo "Installing Inspector Gadget..."
+echo "Installing Inspector Gadget CLI..."
 chmod +x inspector-gadget
 if ! sudo mv inspector-gadget /usr/local/bin/; then
     echo "Error: Failed to move the binary to /usr/local/bin/"
     exit 1
 fi
 
-echo "Inspector Gadget installed successfully in /usr/local/bin"
+echo "Inspector Gadget CLI installed successfully in /usr/local/bin"
 echo "Verifying installation..."
-if inspector-gadget --version; then
-    echo "Inspector Gadget installed successfully!"
+if inspector-gadget --help; then
+    echo "Inspector Gadget CLI installed successfully!"
 else
     echo "Error: Installation verification failed. Please check your PATH and try running 'inspector-gadget --version' manually."
 fi


### PR DESCRIPTION
- Add conditional logic to the build and list target directory steps to support builds for specific targets
- Update the upload release asset step to use the correct target directory based on the matrix target
- Add support for the `aarch64-apple-darwin` target for macOS
- Update the install script to detect `arm64` architecture in addition to `aarch64`
- Update the binary download URL and related messages in the install script to use the correct repository name