### PR TITLE
ci: Add shell: bash to build and list target directory steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
           echo "LD_LIBRARY_PATH=/usr/local/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: 🔨 Build project
+        shell: bash
         run: |
           if [ "${{ matrix.target }}" != "" ]; then
             cargo build --release --verbose --target ${{ matrix.target }}
@@ -124,6 +125,7 @@ jobs:
           PKG_CONFIG_PATH: ${{ matrix.os == 'ubuntu-latest' && '/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH' || '' }}
 
       - name: 📋 List target directory
+        shell: bash
         run: |
           if [ "${{ matrix.target }}" != "" ]; then
             ls -R ./target/${{ matrix.target }}/release


### PR DESCRIPTION
The commit message summarizes the changes made to the `.github/workflows/release.yml` file:

- Added `shell: bash` to the "List target directory" and "Build project" steps to explicitly use the Bash shell for these commands. This ensures consistent shell behavior across different operating systems.
- The changes are related to the CI/CD workflow configuration, hence the "ci:" prefix.