### PR TITLE
feat: Add Linux dependencies installation step to release workflow

### DIFF
--- a/.github/workflows/release_v2.yml
+++ b/.github/workflows/release_v2.yml
@@ -54,6 +54,12 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           targets: ${{ matrix.target }}
 
+      - name: 📦 Install dependencies (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools libssl-dev pkg-config
+
       - name: 🔨 Build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
This change adds a new step to the release workflow on the 'ubuntu-latest' platform to install necessary dependencies for building the project, including `musl-tools`, `libssl-dev`, and `pkg-config`. This ensures consistent build environment across platforms and improves the reliability of the release process.