### PR TITLE
fix: Replace cross with Docker for Linux build

### DIFF
--- a/.github/workflows/release_v2.yml
+++ b/.github/workflows/release_v2.yml
@@ -54,13 +54,14 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           targets: ${{ matrix.target }}
 
-      - name: 📦 Install cross (Linux)
+      - name: 🐳 Set up Docker for Linux build
         if: matrix.os == 'ubuntu-latest'
-        run: cargo install cross
+        uses: docker/setup-buildx-action@v1
 
       - name: 🔨 Build (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: cross build --release --target ${{ matrix.target }}
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/home/rust/src ekidd/rust-musl-builder:stable cargo build --release --target ${{ matrix.target }}
 
       - name: 🔨 Build (macOS and Windows)
         if: matrix.os != 'ubuntu-latest'


### PR DESCRIPTION
The commit message focuses on the main change, which is replacing the use of the `cross` tool with a Docker-based build for the Linux target. This change is made to improve the reliability and consistency of the build process.

The key changes are:

- Removed the installation of the `cross` tool for the Linux build.
- Added the use of the `docker/setup-buildx-action` to set up Docker for the Linux build.
- Updated the Linux build command to use a Docker-based build with the `ekidd/rust-musl-builder:stable` image.

This change ensures that the Linux build is performed in a consistent and reliable environment, without relying on the external `cross` tool.