### PR TITLE
feat: Optimize Docker build process for Linux targets

### DIFF
--- a/.github/workflows/release_v2.yml
+++ b/.github/workflows/release_v2.yml
@@ -61,7 +61,11 @@ jobs:
       - name: 🔨 Build (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          docker run --rm -v ${{ github.workspace }}:/home/rust/src ekidd/rust-musl-builder:stable cargo build --release --target ${{ matrix.target }}
+          docker run --rm -v ${{ github.workspace }}:/home/rust/src \
+            -e CARGO_HOME=/home/rust/.cargo \
+            --user $(id -u):$(id -g) \
+            ekidd/rust-musl-builder:stable \
+            cargo build --release --target ${{ matrix.target }}
 
       - name: 🔨 Build (macOS and Windows)
         if: matrix.os != 'ubuntu-latest'


### PR DESCRIPTION
The changes in this commit improve the Docker build process for Linux targets by:

- Adding the `CARGO_HOME=/home/rust/.cargo` environment variable to the Docker run command. This ensures that the Cargo cache is correctly set up within the Docker container.
- Using the `--user $(id -u):$(id -g)` option to run the Docker container with the same user and group as the current user. This helps to ensure that the build artifacts have the correct ownership.

These changes should help to improve the build reliability and consistency for Linux targets.